### PR TITLE
fix: actually provide GitHub url for GitHub diff button

### DIFF
--- a/src/main/java/io/papermc/fill/discord/DiscordNotifier.java
+++ b/src/main/java/io/papermc/fill/discord/DiscordNotifier.java
@@ -175,7 +175,7 @@ public class DiscordNotifier implements BuildPublishListener {
     if (buildBefore != null && !buildBefore.commits().isEmpty() && !build.commits().isEmpty()) {
       final String url = String.format(
         Locale.ROOT,
-        "https://diffs.dev/?github_url=https://github.com/%s/%s/compare/%s..%s",
+        "https://github.com/%s/%s/compare/%s..%s",
         repository.owner(),
         repository.name(),
         buildBefore.commits().getFirst().sha(),


### PR DESCRIPTION
Since it says "GitHub Diff" in the button i think it should also like to GH.