### PR TITLE
feat: Webhook notifications for Fill events

### DIFF
--- a/dev/test.http
+++ b/dev/test.http
@@ -1,5 +1,5 @@
 ### create a presigned upload URL
-POST localhost:8080/v3/upload
+POST localhost:8080/v3/publishing/stage
 Content-Type: application/json
 Authorization: Basic admin admin
 
@@ -28,7 +28,7 @@ x-amz-meta-sha256: 66a045b452102c59d840ec097d59d9467e13a3f34f6494e539ffd32c1bb35
 < test.txt
 
 ### publish a build
-POST localhost:8080/v3/publish
+POST localhost:8080/v3/publishing/publish
 Content-Type: application/json
 Authorization: Basic admin admin
 

--- a/src/main/java/io/papermc/fill/controller/GraphMutationController.java
+++ b/src/main/java/io/papermc/fill/controller/GraphMutationController.java
@@ -24,6 +24,7 @@ import io.papermc.fill.database.ProjectRepository;
 import io.papermc.fill.database.VersionEntity;
 import io.papermc.fill.database.VersionRepository;
 import io.papermc.fill.database.WebhookEntity;
+import io.papermc.fill.event.AsyncEventPublisher;
 import io.papermc.fill.event.FillEvent;
 import io.papermc.fill.exception.BuildNotFoundException;
 import io.papermc.fill.exception.DuplicateFamilyException;
@@ -61,7 +62,6 @@ import java.util.Date;
 import org.bson.types.ObjectId;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -76,7 +76,7 @@ public class GraphMutationController {
   private final VersionRepository versions;
   private final BuildRepository builds;
   private final WebhookService webhooks;
-  private final ApplicationEventPublisher events;
+  private final AsyncEventPublisher events;
 
   @Autowired
   public GraphMutationController(
@@ -86,7 +86,7 @@ public class GraphMutationController {
     final VersionRepository versions,
     final BuildRepository builds,
     final WebhookService webhooks,
-    final ApplicationEventPublisher events
+    final AsyncEventPublisher events
   ) {
     this.clock = clock;
     this.projects = projects;
@@ -171,7 +171,7 @@ public class GraphMutationController {
       Support.SUPPORTED,
       input.java()
     ));
-    this.events.publishEvent(new FillEvent.VersionCreated(createdAt, project, entity));
+    this.events.publish(new FillEvent.VersionCreated(createdAt, project, entity));
     return new CreateVersionPayload(entity);
   }
 
@@ -189,7 +189,7 @@ public class GraphMutationController {
     }
     version.setJava(input.java());
     version = this.versions.save(version);
-    this.events.publishEvent(new FillEvent.VersionUpdated(this.clock.instant(), project, version));
+    this.events.publish(new FillEvent.VersionUpdated(this.clock.instant(), project, version));
     return new UpdateVersionPayload(version);
   }
 
@@ -224,7 +224,7 @@ public class GraphMutationController {
     version.setMostRecentPromotedBuild(build);
     version = this.versions.save(version);
 
-    this.events.publishEvent(new FillEvent.BuildPromoted(this.clock.instant(), project, version, build));
+    this.events.publish(new FillEvent.BuildPromoted(this.clock.instant(), project, version, build));
 
     return new PromoteBuildPayload(version, build);
   }

--- a/src/main/java/io/papermc/fill/controller/GraphMutationController.java
+++ b/src/main/java/io/papermc/fill/controller/GraphMutationController.java
@@ -23,6 +23,8 @@ import io.papermc.fill.database.ProjectEntity;
 import io.papermc.fill.database.ProjectRepository;
 import io.papermc.fill.database.VersionEntity;
 import io.papermc.fill.database.VersionRepository;
+import io.papermc.fill.database.WebhookEntity;
+import io.papermc.fill.event.FillEvent;
 import io.papermc.fill.exception.BuildNotFoundException;
 import io.papermc.fill.exception.DuplicateFamilyException;
 import io.papermc.fill.exception.DuplicateVersionException;
@@ -33,27 +35,33 @@ import io.papermc.fill.exception.VersionInUseException;
 import io.papermc.fill.exception.VersionNotFoundException;
 import io.papermc.fill.graphql.input.CreateFamilyInput;
 import io.papermc.fill.graphql.input.CreateVersionInput;
+import io.papermc.fill.graphql.input.CreateWebhookInput;
 import io.papermc.fill.graphql.input.DeleteFamilyInput;
 import io.papermc.fill.graphql.input.DeleteVersionInput;
+import io.papermc.fill.graphql.input.DeleteWebhookInput;
 import io.papermc.fill.graphql.input.PromoteBuildInput;
 import io.papermc.fill.graphql.input.UpdateFamilyInput;
 import io.papermc.fill.graphql.input.UpdateVersionInput;
 import io.papermc.fill.graphql.payload.CreateFamilyPayload;
 import io.papermc.fill.graphql.payload.CreateVersionPayload;
+import io.papermc.fill.graphql.payload.CreateWebhookPayload;
 import io.papermc.fill.graphql.payload.DeleteFamilyPayload;
 import io.papermc.fill.graphql.payload.DeleteVersionPayload;
+import io.papermc.fill.graphql.payload.DeleteWebhookPayload;
 import io.papermc.fill.graphql.payload.PromoteBuildPayload;
 import io.papermc.fill.graphql.payload.UpdateFamilyPayload;
 import io.papermc.fill.graphql.payload.UpdateVersionPayload;
 import io.papermc.fill.model.BuildChannel;
 import io.papermc.fill.model.Java;
 import io.papermc.fill.model.Support;
+import io.papermc.fill.service.WebhookService;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Date;
 import org.bson.types.ObjectId;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -67,6 +75,8 @@ public class GraphMutationController {
   private final FamilyRepository families;
   private final VersionRepository versions;
   private final BuildRepository builds;
+  private final WebhookService webhooks;
+  private final ApplicationEventPublisher events;
 
   @Autowired
   public GraphMutationController(
@@ -74,13 +84,17 @@ public class GraphMutationController {
     final ProjectRepository projects,
     final FamilyRepository families,
     final VersionRepository versions,
-    final BuildRepository builds
+    final BuildRepository builds,
+    final WebhookService webhooks,
+    final ApplicationEventPublisher events
   ) {
     this.clock = clock;
     this.projects = projects;
     this.families = families;
     this.versions = versions;
     this.builds = builds;
+    this.webhooks = webhooks;
+    this.events = events;
   }
 
   @MutationMapping("createFamily")
@@ -157,6 +171,7 @@ public class GraphMutationController {
       Support.SUPPORTED,
       input.java()
     ));
+    this.events.publishEvent(new FillEvent.VersionCreated(createdAt, project, entity));
     return new CreateVersionPayload(entity);
   }
 
@@ -174,6 +189,7 @@ public class GraphMutationController {
     }
     version.setJava(input.java());
     version = this.versions.save(version);
+    this.events.publishEvent(new FillEvent.VersionUpdated(this.clock.instant(), project, version));
     return new UpdateVersionPayload(version);
   }
 
@@ -208,6 +224,27 @@ public class GraphMutationController {
     version.setMostRecentPromotedBuild(build);
     version = this.versions.save(version);
 
+    this.events.publishEvent(new FillEvent.BuildPromoted(this.clock.instant(), project, version, build));
+
     return new PromoteBuildPayload(version, build);
+  }
+
+  @MutationMapping("createWebhook")
+  @PreAuthorize("hasRole('API_MANAGE')")
+  public CreateWebhookPayload createWebhook(
+    @Argument
+    final CreateWebhookInput input
+  ) {
+    final WebhookEntity webhook = this.webhooks.create(input.url());
+    return new CreateWebhookPayload(webhook, webhook.secret());
+  }
+
+  @MutationMapping("deleteWebhook")
+  @PreAuthorize("hasRole('API_MANAGE')")
+  public DeleteWebhookPayload deleteWebhook(
+    @Argument
+    final DeleteWebhookInput input
+  ) {
+    return new DeleteWebhookPayload(this.webhooks.delete(input.id()));
   }
 }

--- a/src/main/java/io/papermc/fill/controller/GraphMutationController.java
+++ b/src/main/java/io/papermc/fill/controller/GraphMutationController.java
@@ -115,6 +115,7 @@ public class GraphMutationController {
       input.key(),
       input.java()
     ));
+    this.events.publish(new FillEvent.FamilyCreated(createdAt, project, entity));
     return new CreateFamilyPayload(entity);
   }
 
@@ -131,6 +132,7 @@ public class GraphMutationController {
       family.setJava(java);
     }
     family = this.families.save(family);
+    this.events.publish(new FillEvent.FamilyUpdated(this.clock.instant(), project, family));
     return new UpdateFamilyPayload(family);
   }
 
@@ -146,6 +148,7 @@ public class GraphMutationController {
       throw new FamilyInUseException("Cannot delete this family because one or more versions are still associated with it.");
     }
     this.families.delete(family);
+    this.events.publish(new FillEvent.FamilyDeleted(this.clock.instant(), project, family));
     return new DeleteFamilyPayload(true);
   }
 

--- a/src/main/java/io/papermc/fill/controller/GraphQueryController.java
+++ b/src/main/java/io/papermc/fill/controller/GraphQueryController.java
@@ -38,6 +38,7 @@ import io.papermc.fill.model.BuildChannel;
 import io.papermc.fill.model.BuildWithDownloads;
 import io.papermc.fill.model.BuildWithDownloadsImpl;
 import io.papermc.fill.model.Commit;
+import io.papermc.fill.model.DeliveryStatus;
 import io.papermc.fill.model.DownloadWithUrl;
 import io.papermc.fill.model.Java;
 import io.papermc.fill.model.Keyed;
@@ -356,7 +357,7 @@ public class GraphQueryController {
   }
 
   @SchemaMapping(typeName = "Webhook", field = "lastDeliveryStatus")
-  public @Nullable String mapWebhookLastDeliveryStatus(final WebhookEntity webhook) {
+  public @Nullable DeliveryStatus mapWebhookLastDeliveryStatus(final WebhookEntity webhook) {
     return webhook.lastDeliveryStatus();
   }
 

--- a/src/main/java/io/papermc/fill/controller/GraphQueryController.java
+++ b/src/main/java/io/papermc/fill/controller/GraphQueryController.java
@@ -24,6 +24,7 @@ import io.papermc.fill.database.ProjectEntity;
 import io.papermc.fill.database.ProjectRepository;
 import io.papermc.fill.database.VersionEntity;
 import io.papermc.fill.database.VersionRepository;
+import io.papermc.fill.database.WebhookEntity;
 import io.papermc.fill.exception.BuildNotFoundException;
 import io.papermc.fill.exception.FamilyNotFoundException;
 import io.papermc.fill.exception.ProjectNotFoundException;
@@ -46,6 +47,7 @@ import io.papermc.fill.model.SupportStatus;
 import io.papermc.fill.model.Timestamped;
 import io.papermc.fill.model.Version;
 import io.papermc.fill.service.StorageService;
+import io.papermc.fill.service.WebhookService;
 import io.papermc.fill.util.graphql.CursorCodec;
 import io.papermc.fill.util.graphql.CursorPaginator;
 import java.net.URI;
@@ -65,6 +67,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.graphql.data.method.annotation.SchemaMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 
 @Controller
@@ -88,6 +91,7 @@ public class GraphQueryController {
   private final VersionRepository versions;
   private final BuildRepository builds;
   private final StorageService storage;
+  private final WebhookService webhooks;
 
   @Autowired
   public GraphQueryController(
@@ -95,13 +99,15 @@ public class GraphQueryController {
     final FamilyRepository families,
     final VersionRepository versions,
     final BuildRepository builds,
-    final StorageService storage
+    final StorageService storage,
+    final WebhookService webhooks
   ) {
     this.projects = projects;
     this.families = families;
     this.versions = versions;
     this.builds = builds;
     this.storage = storage;
+    this.webhooks = webhooks;
   }
 
   @QueryMapping("projects")
@@ -326,6 +332,41 @@ public class GraphQueryController {
     final String key
   ) {
     return build.getDownloadByKey(key);
+  }
+
+  @QueryMapping("webhooks")
+  @PreAuthorize("hasRole('API_MANAGE')")
+  public List<WebhookEntity> getWebhooks() {
+    return this.webhooks.list();
+  }
+
+  @SchemaMapping(typeName = "Webhook", field = "id")
+  public String mapWebhookId(final WebhookEntity webhook) {
+    return webhook.id();
+  }
+
+  @SchemaMapping(typeName = "Webhook", field = "url")
+  public String mapWebhookUrl(final WebhookEntity webhook) {
+    return webhook.url();
+  }
+
+  @SchemaMapping(typeName = "Webhook", field = "createdAt")
+  public ZonedDateTime mapWebhookCreatedAt(final WebhookEntity webhook) {
+    return webhook.createdAt().atZone(ZoneOffset.UTC);
+  }
+
+  @SchemaMapping(typeName = "Webhook", field = "lastDeliveryStatus")
+  public @Nullable String mapWebhookLastDeliveryStatus(final WebhookEntity webhook) {
+    return webhook.lastDeliveryStatus();
+  }
+
+  @SchemaMapping(typeName = "Webhook", field = "lastDeliveryAt")
+  public @Nullable ZonedDateTime mapWebhookLastDeliveryAt(final WebhookEntity webhook) {
+    final Instant lastDeliveryAt = webhook.lastDeliveryAt();
+    if (lastDeliveryAt == null) {
+      return null;
+    }
+    return lastDeliveryAt.atZone(ZoneOffset.UTC);
   }
 
   private Function<BuildEntity, BuildWithDownloads<DownloadWithUrl>> mapBuild(final Project project, final Version version) {

--- a/src/main/java/io/papermc/fill/controller/PublishController.java
+++ b/src/main/java/io/papermc/fill/controller/PublishController.java
@@ -25,6 +25,7 @@ import io.papermc.fill.database.ProjectEntity;
 import io.papermc.fill.database.ProjectRepository;
 import io.papermc.fill.database.VersionEntity;
 import io.papermc.fill.database.VersionRepository;
+import io.papermc.fill.event.AsyncEventPublisher;
 import io.papermc.fill.event.FillEvent;
 import io.papermc.fill.exception.ChecksumMismatchException;
 import io.papermc.fill.exception.DownloadNotFoundException;
@@ -64,7 +65,6 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -92,7 +92,7 @@ public class PublishController {
   private final BuildRepository builds;
   private final PublishingService publishing;
   private final StorageService storage;
-  private final ApplicationEventPublisher events;
+  private final AsyncEventPublisher events;
   private final LoadingCache<UUID, StagingInstance> instances = Caffeine.newBuilder()
     .expireAfterAccess(Duration.ofMinutes(5))
     .build(_ -> new StagingInstance());
@@ -105,7 +105,7 @@ public class PublishController {
     final BuildRepository builds,
     final PublishingService publishing,
     final StorageService storage,
-    final ApplicationEventPublisher events
+    final AsyncEventPublisher events
   ) {
     this.projects = projects;
     this.families = families;
@@ -233,7 +233,7 @@ public class PublishController {
 
     this.builds.save(build);
 
-    this.events.publishEvent(new FillEvent.BuildPublished(createdAt, project, version, build));
+    this.events.publish(new FillEvent.BuildPublished(createdAt, project, version, build));
 
     return Responses.created(new PublishResponse(true, build._id()));
   }

--- a/src/main/java/io/papermc/fill/controller/PublishController.java
+++ b/src/main/java/io/papermc/fill/controller/PublishController.java
@@ -25,6 +25,7 @@ import io.papermc.fill.database.ProjectEntity;
 import io.papermc.fill.database.ProjectRepository;
 import io.papermc.fill.database.VersionEntity;
 import io.papermc.fill.database.VersionRepository;
+import io.papermc.fill.event.FillEvent;
 import io.papermc.fill.exception.ChecksumMismatchException;
 import io.papermc.fill.exception.DownloadNotFoundException;
 import io.papermc.fill.exception.DuplicateBuildException;
@@ -42,7 +43,6 @@ import io.papermc.fill.model.request.UploadRequest;
 import io.papermc.fill.model.request.v3.PublishRequest;
 import io.papermc.fill.model.response.PublishResponse;
 import io.papermc.fill.model.response.UploadResponse;
-import io.papermc.fill.notification.BuildListener;
 import io.papermc.fill.service.PublishingService;
 import io.papermc.fill.service.StorageService;
 import io.papermc.fill.util.crypto.HashAlgorithm;
@@ -57,7 +57,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
-import java.util.Set;
 import java.util.UUID;
 import org.bson.types.ObjectId;
 import org.jspecify.annotations.NullMarked;
@@ -65,6 +64,7 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -92,7 +92,7 @@ public class PublishController {
   private final BuildRepository builds;
   private final PublishingService publishing;
   private final StorageService storage;
-  private final Set<BuildListener> buildListeners;
+  private final ApplicationEventPublisher events;
   private final LoadingCache<UUID, StagingInstance> instances = Caffeine.newBuilder()
     .expireAfterAccess(Duration.ofMinutes(5))
     .build(_ -> new StagingInstance());
@@ -105,7 +105,7 @@ public class PublishController {
     final BuildRepository builds,
     final PublishingService publishing,
     final StorageService storage,
-    final Set<BuildListener> buildListeners
+    final ApplicationEventPublisher events
   ) {
     this.projects = projects;
     this.families = families;
@@ -113,7 +113,7 @@ public class PublishController {
     this.builds = builds;
     this.publishing = publishing;
     this.storage = storage;
-    this.buildListeners = buildListeners;
+    this.events = events;
   }
 
   @CrossOrigin(methods = RequestMethod.POST)
@@ -233,9 +233,7 @@ public class PublishController {
 
     this.builds.save(build);
 
-    for (final BuildListener listener : this.buildListeners) {
-      listener.onBuildPublished(project, version, build);
-    }
+    this.events.publishEvent(new FillEvent.BuildPublished(createdAt, project, version, build));
 
     return Responses.created(new PublishResponse(true, build._id()));
   }

--- a/src/main/java/io/papermc/fill/controller/Publishing3Controller.java
+++ b/src/main/java/io/papermc/fill/controller/Publishing3Controller.java
@@ -23,6 +23,7 @@ import io.papermc.fill.database.ProjectEntity;
 import io.papermc.fill.database.ProjectRepository;
 import io.papermc.fill.database.VersionEntity;
 import io.papermc.fill.database.VersionRepository;
+import io.papermc.fill.event.FillEvent;
 import io.papermc.fill.exception.DuplicateBuildException;
 import io.papermc.fill.exception.FamilyNotFoundException;
 import io.papermc.fill.exception.ProjectNotFoundException;
@@ -36,19 +37,18 @@ import io.papermc.fill.model.request.v3.PublishRequest;
 import io.papermc.fill.model.request.v3.StageRequest;
 import io.papermc.fill.model.response.v3.PublishResponse;
 import io.papermc.fill.model.response.v3.StageResponse;
-import io.papermc.fill.notification.BuildListener;
 import io.papermc.fill.service.StorageService;
 import io.papermc.fill.util.http.Responses;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.bson.types.ObjectId;
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -69,7 +69,7 @@ public class Publishing3Controller {
   private final VersionRepository versions;
   private final BuildRepository builds;
   private final StorageService storage;
-  private final Set<BuildListener> buildListeners;
+  private final ApplicationEventPublisher events;
 
   @Autowired
   public Publishing3Controller(
@@ -78,14 +78,14 @@ public class Publishing3Controller {
     final VersionRepository versions,
     final BuildRepository builds,
     final StorageService storage,
-    final Set<BuildListener> buildListeners
+    final ApplicationEventPublisher events
   ) {
     this.projects = projects;
     this.families = families;
     this.versions = versions;
     this.builds = builds;
     this.storage = storage;
-    this.buildListeners = buildListeners;
+    this.events = events;
   }
 
   @CrossOrigin(methods = RequestMethod.POST)
@@ -139,6 +139,7 @@ public class Publishing3Controller {
           Support.SUPPORTED,
           null
         ));
+        this.events.publishEvent(new FillEvent.VersionCreated(createdAt, project, version));
       } else {
         throw new VersionNotFoundException();
       }
@@ -186,9 +187,7 @@ public class Publishing3Controller {
     this.builds.save(build);
     this.deleteStagedObjects(request, downloads);
 
-    for (final BuildListener listener : this.buildListeners) {
-      listener.onBuildPublished(project, version, build);
-    }
+    this.events.publishEvent(new FillEvent.BuildPublished(createdAt, project, version, build));
 
     return Responses.created(new PublishResponse(true));
   }

--- a/src/main/java/io/papermc/fill/controller/Publishing3Controller.java
+++ b/src/main/java/io/papermc/fill/controller/Publishing3Controller.java
@@ -23,6 +23,7 @@ import io.papermc.fill.database.ProjectEntity;
 import io.papermc.fill.database.ProjectRepository;
 import io.papermc.fill.database.VersionEntity;
 import io.papermc.fill.database.VersionRepository;
+import io.papermc.fill.event.AsyncEventPublisher;
 import io.papermc.fill.event.FillEvent;
 import io.papermc.fill.exception.DuplicateBuildException;
 import io.papermc.fill.exception.FamilyNotFoundException;
@@ -48,7 +49,6 @@ import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -69,7 +69,7 @@ public class Publishing3Controller {
   private final VersionRepository versions;
   private final BuildRepository builds;
   private final StorageService storage;
-  private final ApplicationEventPublisher events;
+  private final AsyncEventPublisher events;
 
   @Autowired
   public Publishing3Controller(
@@ -78,7 +78,7 @@ public class Publishing3Controller {
     final VersionRepository versions,
     final BuildRepository builds,
     final StorageService storage,
-    final ApplicationEventPublisher events
+    final AsyncEventPublisher events
   ) {
     this.projects = projects;
     this.families = families;
@@ -139,7 +139,7 @@ public class Publishing3Controller {
           Support.SUPPORTED,
           null
         ));
-        this.events.publishEvent(new FillEvent.VersionCreated(createdAt, project, version));
+        this.events.publish(new FillEvent.VersionCreated(createdAt, project, version));
       } else {
         throw new VersionNotFoundException();
       }
@@ -187,7 +187,7 @@ public class Publishing3Controller {
     this.builds.save(build);
     this.deleteStagedObjects(request, downloads);
 
-    this.events.publishEvent(new FillEvent.BuildPublished(createdAt, project, version, build));
+    this.events.publish(new FillEvent.BuildPublished(createdAt, project, version, build));
 
     return Responses.created(new PublishResponse(true));
   }

--- a/src/main/java/io/papermc/fill/database/WebhookEntity.java
+++ b/src/main/java/io/papermc/fill/database/WebhookEntity.java
@@ -25,6 +25,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @NullMarked
 public class WebhookEntity extends AbstractEntity {
   private String url;
+  // Stored in plaintext so deliveries can be signed; anyone with DB access can forge signatures.
   private String secret;
   private @Nullable String lastDeliveryStatus;
   private @Nullable Instant lastDeliveryAt;

--- a/src/main/java/io/papermc/fill/database/WebhookEntity.java
+++ b/src/main/java/io/papermc/fill/database/WebhookEntity.java
@@ -15,6 +15,7 @@
  */
 package io.papermc.fill.database;
 
+import io.papermc.fill.model.DeliveryStatus;
 import java.time.Instant;
 import org.bson.types.ObjectId;
 import org.jspecify.annotations.NullMarked;
@@ -27,7 +28,7 @@ public class WebhookEntity extends AbstractEntity {
   private String url;
   // Stored in plaintext so deliveries can be signed; anyone with DB access can forge signatures.
   private String secret;
-  private @Nullable String lastDeliveryStatus;
+  private @Nullable DeliveryStatus lastDeliveryStatus;
   private @Nullable Instant lastDeliveryAt;
 
   public WebhookEntity() {
@@ -54,7 +55,7 @@ public class WebhookEntity extends AbstractEntity {
     return this.secret;
   }
 
-  public @Nullable String lastDeliveryStatus() {
+  public @Nullable DeliveryStatus lastDeliveryStatus() {
     return this.lastDeliveryStatus;
   }
 

--- a/src/main/java/io/papermc/fill/database/WebhookEntity.java
+++ b/src/main/java/io/papermc/fill/database/WebhookEntity.java
@@ -62,5 +62,4 @@ public class WebhookEntity extends AbstractEntity {
   public @Nullable Instant lastDeliveryAt() {
     return this.lastDeliveryAt;
   }
-
 }

--- a/src/main/java/io/papermc/fill/database/WebhookEntity.java
+++ b/src/main/java/io/papermc/fill/database/WebhookEntity.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 PaperMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.papermc.fill.database;
+
+import java.time.Instant;
+import org.bson.types.ObjectId;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "webhooks")
+@NullMarked
+public class WebhookEntity extends AbstractEntity {
+  private String url;
+  private String secret;
+  private @Nullable String lastDeliveryStatus;
+  private @Nullable Instant lastDeliveryAt;
+
+  public WebhookEntity() {
+  }
+
+  public static WebhookEntity create(final ObjectId _id, final Instant createdAt, final String url, final String secret) {
+    final WebhookEntity entity = new WebhookEntity();
+    entity._id = _id;
+    entity.createdAt = createdAt;
+    entity.url = url;
+    entity.secret = secret;
+    return entity;
+  }
+
+  public String id() {
+    return this._id.toHexString();
+  }
+
+  public String url() {
+    return this.url;
+  }
+
+  public String secret() {
+    return this.secret;
+  }
+
+  public @Nullable String lastDeliveryStatus() {
+    return this.lastDeliveryStatus;
+  }
+
+  public @Nullable Instant lastDeliveryAt() {
+    return this.lastDeliveryAt;
+  }
+
+}

--- a/src/main/java/io/papermc/fill/database/WebhookRepository.java
+++ b/src/main/java/io/papermc/fill/database/WebhookRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 PaperMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.papermc.fill.database;
+
+import java.time.Instant;
+import org.bson.types.ObjectId;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.mongodb.repository.Update;
+import org.springframework.stereotype.Repository;
+
+@NullMarked
+@Repository
+public interface WebhookRepository extends MongoRepository<WebhookEntity, ObjectId> {
+  @Query("{ '_id': ?0 }")
+  @Update("{ '$set': { 'lastDeliveryStatus': ?1, 'lastDeliveryAt': ?2 } }")
+  long updateDelivery(ObjectId id, String status, Instant deliveredAt);
+}

--- a/src/main/java/io/papermc/fill/database/WebhookRepository.java
+++ b/src/main/java/io/papermc/fill/database/WebhookRepository.java
@@ -15,6 +15,7 @@
  */
 package io.papermc.fill.database;
 
+import io.papermc.fill.model.DeliveryStatus;
 import java.time.Instant;
 import org.bson.types.ObjectId;
 import org.jspecify.annotations.NullMarked;
@@ -28,5 +29,5 @@ import org.springframework.stereotype.Repository;
 public interface WebhookRepository extends MongoRepository<WebhookEntity, ObjectId> {
   @Query("{ '_id': ?0 }")
   @Update("{ '$set': { 'lastDeliveryStatus': ?1, 'lastDeliveryAt': ?2 } }")
-  long updateDelivery(ObjectId id, String status, Instant deliveredAt);
+  long updateDelivery(ObjectId id, DeliveryStatus status, Instant deliveredAt);
 }

--- a/src/main/java/io/papermc/fill/event/AsyncEventPublisher.java
+++ b/src/main/java/io/papermc/fill/event/AsyncEventPublisher.java
@@ -15,7 +15,9 @@
  */
 package io.papermc.fill.event;
 
+import io.papermc.fill.util.concurrent.ConcurrentUtil;
 import jakarta.annotation.PreDestroy;
+import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.jspecify.annotations.NullMarked;
@@ -28,6 +30,7 @@ import org.springframework.stereotype.Component;
 @NullMarked
 public final class AsyncEventPublisher {
   private static final Logger LOGGER = LoggerFactory.getLogger(AsyncEventPublisher.class);
+  private static final Duration SHUTDOWN_TIMEOUT = Duration.ofSeconds(5);
 
   private final ApplicationEventPublisher delegate;
   private final ExecutorService executor = Executors.newThreadPerTaskExecutor(
@@ -50,6 +53,6 @@ public final class AsyncEventPublisher {
 
   @PreDestroy
   public void close() {
-    this.executor.shutdown();
+    ConcurrentUtil.shutdownExecutor(this.executor, SHUTDOWN_TIMEOUT);
   }
 }

--- a/src/main/java/io/papermc/fill/event/AsyncEventPublisher.java
+++ b/src/main/java/io/papermc/fill/event/AsyncEventPublisher.java
@@ -30,7 +30,9 @@ public final class AsyncEventPublisher {
   private static final Logger LOGGER = LoggerFactory.getLogger(AsyncEventPublisher.class);
 
   private final ApplicationEventPublisher delegate;
-  private final ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+  private final ExecutorService executor = Executors.newThreadPerTaskExecutor(
+    Thread.ofVirtual().name("fill-event-", 0).factory()
+  );
 
   public AsyncEventPublisher(final ApplicationEventPublisher delegate) {
     this.delegate = delegate;

--- a/src/main/java/io/papermc/fill/event/AsyncEventPublisher.java
+++ b/src/main/java/io/papermc/fill/event/AsyncEventPublisher.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 PaperMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.papermc.fill.event;
+
+import jakarta.annotation.PreDestroy;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@NullMarked
+public final class AsyncEventPublisher {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AsyncEventPublisher.class);
+
+  private final ApplicationEventPublisher delegate;
+  private final ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+
+  public AsyncEventPublisher(final ApplicationEventPublisher delegate) {
+    this.delegate = delegate;
+  }
+
+  public void publish(final FillEvent event) {
+    this.executor.execute(() -> {
+      try {
+        this.delegate.publishEvent(event);
+      } catch (final Exception exception) {
+        LOGGER.error("Event listener failed for {}", event.type(), exception);
+      }
+    });
+  }
+
+  @PreDestroy
+  public void close() {
+    this.executor.shutdown();
+  }
+}

--- a/src/main/java/io/papermc/fill/event/FillEvent.java
+++ b/src/main/java/io/papermc/fill/event/FillEvent.java
@@ -33,6 +33,7 @@ public sealed interface FillEvent permits FillEvent.BuildPublished, FillEvent.Bu
 
   VersionEntity version();
 
+  @NullMarked
   record BuildPublished(
     Instant time,
     ProjectEntity project,
@@ -45,6 +46,7 @@ public sealed interface FillEvent permits FillEvent.BuildPublished, FillEvent.Bu
     }
   }
 
+  @NullMarked
   record BuildPromoted(
     Instant time,
     ProjectEntity project,
@@ -57,6 +59,7 @@ public sealed interface FillEvent permits FillEvent.BuildPublished, FillEvent.Bu
     }
   }
 
+  @NullMarked
   record VersionCreated(
     Instant time,
     ProjectEntity project,
@@ -68,6 +71,7 @@ public sealed interface FillEvent permits FillEvent.BuildPublished, FillEvent.Bu
     }
   }
 
+  @NullMarked
   record VersionUpdated(
     Instant time,
     ProjectEntity project,

--- a/src/main/java/io/papermc/fill/event/FillEvent.java
+++ b/src/main/java/io/papermc/fill/event/FillEvent.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 PaperMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.papermc.fill.event;
+
+import io.papermc.fill.database.BuildEntity;
+import io.papermc.fill.database.ProjectEntity;
+import io.papermc.fill.database.VersionEntity;
+import io.papermc.fill.model.BuildWithDownloads;
+import io.papermc.fill.model.Download;
+import java.time.Instant;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public sealed interface FillEvent permits FillEvent.BuildPublished, FillEvent.BuildPromoted, FillEvent.VersionCreated, FillEvent.VersionUpdated {
+  String type();
+
+  Instant time();
+
+  ProjectEntity project();
+
+  VersionEntity version();
+
+  record BuildPublished(
+    Instant time,
+    ProjectEntity project,
+    VersionEntity version,
+    BuildWithDownloads<Download> build
+  ) implements FillEvent {
+    @Override
+    public String type() {
+      return "build.published";
+    }
+  }
+
+  record BuildPromoted(
+    Instant time,
+    ProjectEntity project,
+    VersionEntity version,
+    BuildEntity build
+  ) implements FillEvent {
+    @Override
+    public String type() {
+      return "build.promoted";
+    }
+  }
+
+  record VersionCreated(
+    Instant time,
+    ProjectEntity project,
+    VersionEntity version
+  ) implements FillEvent {
+    @Override
+    public String type() {
+      return "version.created";
+    }
+  }
+
+  record VersionUpdated(
+    Instant time,
+    ProjectEntity project,
+    VersionEntity version
+  ) implements FillEvent {
+    @Override
+    public String type() {
+      return "version.updated";
+    }
+  }
+}

--- a/src/main/java/io/papermc/fill/event/FillEvent.java
+++ b/src/main/java/io/papermc/fill/event/FillEvent.java
@@ -16,6 +16,7 @@
 package io.papermc.fill.event;
 
 import io.papermc.fill.database.BuildEntity;
+import io.papermc.fill.database.FamilyEntity;
 import io.papermc.fill.database.ProjectEntity;
 import io.papermc.fill.database.VersionEntity;
 import io.papermc.fill.model.BuildWithDownloads;
@@ -24,14 +25,28 @@ import java.time.Instant;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public sealed interface FillEvent permits FillEvent.BuildPublished, FillEvent.BuildPromoted, FillEvent.VersionCreated, FillEvent.VersionUpdated {
+public sealed interface FillEvent permits FillEvent.ProjectEvent {
   String type();
 
   Instant time();
 
-  ProjectEntity project();
+  /** An event concerning a project. */
+  @NullMarked
+  sealed interface ProjectEvent extends FillEvent permits FillEvent.VersionEvent, FillEvent.FamilyEvent {
+    ProjectEntity project();
+  }
 
-  VersionEntity version();
+  /** An event concerning a version (and therefore its project). */
+  @NullMarked
+  sealed interface VersionEvent extends ProjectEvent permits FillEvent.BuildPublished, FillEvent.BuildPromoted, FillEvent.VersionCreated, FillEvent.VersionUpdated {
+    VersionEntity version();
+  }
+
+  /** An event concerning a version group (a family). */
+  @NullMarked
+  sealed interface FamilyEvent extends ProjectEvent permits FillEvent.FamilyCreated, FillEvent.FamilyUpdated, FillEvent.FamilyDeleted {
+    FamilyEntity family();
+  }
 
   @NullMarked
   record BuildPublished(
@@ -39,7 +54,7 @@ public sealed interface FillEvent permits FillEvent.BuildPublished, FillEvent.Bu
     ProjectEntity project,
     VersionEntity version,
     BuildWithDownloads<Download> build
-  ) implements FillEvent {
+  ) implements VersionEvent {
     @Override
     public String type() {
       return "build.published";
@@ -52,7 +67,7 @@ public sealed interface FillEvent permits FillEvent.BuildPublished, FillEvent.Bu
     ProjectEntity project,
     VersionEntity version,
     BuildEntity build
-  ) implements FillEvent {
+  ) implements VersionEvent {
     @Override
     public String type() {
       return "build.promoted";
@@ -64,7 +79,7 @@ public sealed interface FillEvent permits FillEvent.BuildPublished, FillEvent.Bu
     Instant time,
     ProjectEntity project,
     VersionEntity version
-  ) implements FillEvent {
+  ) implements VersionEvent {
     @Override
     public String type() {
       return "version.created";
@@ -76,10 +91,46 @@ public sealed interface FillEvent permits FillEvent.BuildPublished, FillEvent.Bu
     Instant time,
     ProjectEntity project,
     VersionEntity version
-  ) implements FillEvent {
+  ) implements VersionEvent {
     @Override
     public String type() {
       return "version.updated";
+    }
+  }
+
+  @NullMarked
+  record FamilyCreated(
+    Instant time,
+    ProjectEntity project,
+    FamilyEntity family
+  ) implements FamilyEvent {
+    @Override
+    public String type() {
+      return "family.created";
+    }
+  }
+
+  @NullMarked
+  record FamilyUpdated(
+    Instant time,
+    ProjectEntity project,
+    FamilyEntity family
+  ) implements FamilyEvent {
+    @Override
+    public String type() {
+      return "family.updated";
+    }
+  }
+
+  @NullMarked
+  record FamilyDeleted(
+    Instant time,
+    ProjectEntity project,
+    FamilyEntity family
+  ) implements FamilyEvent {
+    @Override
+    public String type() {
+      return "family.deleted";
     }
   }
 }

--- a/src/main/java/io/papermc/fill/exception/WebhookNotFoundException.java
+++ b/src/main/java/io/papermc/fill/exception/WebhookNotFoundException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 PaperMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.papermc.fill.exception;
+
+import graphql.ErrorClassification;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.graphql.execution.ErrorType;
+
+@NullMarked
+public class WebhookNotFoundException extends AppException {
+  public WebhookNotFoundException() {
+    super("No webhook was found with the given identifier.");
+  }
+
+  @Override
+  public ErrorClassification getGraphErrorClassification() {
+    return ErrorType.NOT_FOUND;
+  }
+}

--- a/src/main/java/io/papermc/fill/graphql/input/CreateWebhookInput.java
+++ b/src/main/java/io/papermc/fill/graphql/input/CreateWebhookInput.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 PaperMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.papermc.fill.graphql.input;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public record CreateWebhookInput(
+  String url
+) {
+}

--- a/src/main/java/io/papermc/fill/graphql/input/DeleteWebhookInput.java
+++ b/src/main/java/io/papermc/fill/graphql/input/DeleteWebhookInput.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 PaperMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.papermc.fill.graphql.input;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public record DeleteWebhookInput(
+  String id
+) {
+}

--- a/src/main/java/io/papermc/fill/graphql/payload/CreateWebhookPayload.java
+++ b/src/main/java/io/papermc/fill/graphql/payload/CreateWebhookPayload.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 PaperMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.papermc.fill.graphql.payload;
+
+import io.papermc.fill.database.WebhookEntity;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The secret is only returned when a webhook is created and can never be
+ * retrieved again afterwards.
+ */
+@NullMarked
+public record CreateWebhookPayload(
+  WebhookEntity webhook,
+  String secret
+) {
+}

--- a/src/main/java/io/papermc/fill/graphql/payload/DeleteWebhookPayload.java
+++ b/src/main/java/io/papermc/fill/graphql/payload/DeleteWebhookPayload.java
@@ -13,19 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.papermc.fill.notification;
+package io.papermc.fill.graphql.payload;
 
-import io.papermc.fill.database.ProjectEntity;
-import io.papermc.fill.database.VersionEntity;
-import io.papermc.fill.model.BuildWithDownloads;
-import io.papermc.fill.model.Download;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public interface BuildListener {
-  void onBuildPublished(
-    final ProjectEntity project,
-    final VersionEntity version,
-    final BuildWithDownloads<Download> build
-  );
+public record DeleteWebhookPayload(
+  boolean ok
+) {
 }

--- a/src/main/java/io/papermc/fill/model/DeliveryStatus.java
+++ b/src/main/java/io/papermc/fill/model/DeliveryStatus.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 PaperMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.papermc.fill.model;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public enum DeliveryStatus {
+  DELIVERED,
+  FAILED,
+}

--- a/src/main/java/io/papermc/fill/notification/DiscordNotificationPublisher.java
+++ b/src/main/java/io/papermc/fill/notification/DiscordNotificationPublisher.java
@@ -33,6 +33,7 @@ import io.papermc.fill.database.BuildEntity;
 import io.papermc.fill.database.BuildRepository;
 import io.papermc.fill.database.ProjectEntity;
 import io.papermc.fill.database.VersionEntity;
+import io.papermc.fill.event.FillEvent;
 import io.papermc.fill.model.Build;
 import io.papermc.fill.model.BuildWithDownloads;
 import io.papermc.fill.model.Commit;
@@ -54,12 +55,13 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 @Component
 @ConditionalOnProperty("app.discord.token")
 @NullMarked
-public class DiscordNotificationPublisher implements BuildListener {
+public class DiscordNotificationPublisher {
   private final ApplicationDiscordProperties properties;
 
   private final BuildRepository builds;
@@ -80,8 +82,11 @@ public class DiscordNotificationPublisher implements BuildListener {
     this.discord = discord;
   }
 
-  @Override
-  public void onBuildPublished(final ProjectEntity project, final VersionEntity version, final BuildWithDownloads<Download> build) {
+  @EventListener
+  public void onBuildPublished(final FillEvent.BuildPublished event) {
+    final ProjectEntity project = event.project();
+    final VersionEntity version = event.version();
+    final BuildWithDownloads<Download> build = event.build();
     final GitRepository repository = Objects.requireNonNullElse(version.gitRepository(), project.gitRepository());
     final Container content = this.createContent(project, version, repository, build);
     final Button downloadButton = this.createDownloadButton(project, version, build);

--- a/src/main/java/io/papermc/fill/notification/WebhookPayload.java
+++ b/src/main/java/io/papermc/fill/notification/WebhookPayload.java
@@ -16,6 +16,7 @@
 package io.papermc.fill.notification;
 
 import io.papermc.fill.event.FillEvent;
+import io.papermc.fill.model.BuildChannel;
 import java.time.Instant;
 import org.jspecify.annotations.NullMarked;
 
@@ -43,7 +44,7 @@ public record WebhookPayload(String type, Instant timestamp, Data data) {
   public record VersionRef(String id, String key) {
   }
 
-  public record BuildRef(String id, int number, String channel) {
+  public record BuildRef(String id, int number, BuildChannel channel) {
   }
 
   public static WebhookPayload from(final FillEvent event) {
@@ -53,12 +54,12 @@ public record WebhookPayload(String type, Instant timestamp, Data data) {
       case FillEvent.BuildPublished e -> new Data.BuildPublished(
         project,
         version,
-        new BuildRef(e.build().id(), e.build().number(), e.build().channel().name())
+        new BuildRef(e.build().id(), e.build().number(), e.build().channel())
       );
       case FillEvent.BuildPromoted e -> new Data.BuildPromoted(
         project,
         version,
-        new BuildRef(e.build().id(), e.build().number(), e.build().channel().name())
+        new BuildRef(e.build().id(), e.build().number(), e.build().channel())
       );
       case FillEvent.VersionCreated _ -> new Data.VersionCreated(project, version);
       case FillEvent.VersionUpdated _ -> new Data.VersionUpdated(project, version);

--- a/src/main/java/io/papermc/fill/notification/WebhookPayload.java
+++ b/src/main/java/io/papermc/fill/notification/WebhookPayload.java
@@ -24,26 +24,34 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public record WebhookPayload(String type, Instant timestamp, Data data) {
 
+  @NullMarked
   public sealed interface Data permits Data.BuildPublished, Data.BuildPromoted, Data.VersionCreated, Data.VersionUpdated {
+    @NullMarked
     record BuildPublished(ProjectRef project, VersionRef version, BuildRef build) implements Data {
     }
 
+    @NullMarked
     record BuildPromoted(ProjectRef project, VersionRef version, BuildRef build) implements Data {
     }
 
+    @NullMarked
     record VersionCreated(ProjectRef project, VersionRef version) implements Data {
     }
 
+    @NullMarked
     record VersionUpdated(ProjectRef project, VersionRef version) implements Data {
     }
   }
 
+  @NullMarked
   public record ProjectRef(String id, String key) {
   }
 
+  @NullMarked
   public record VersionRef(String id, String key) {
   }
 
+  @NullMarked
   public record BuildRef(String id, int number, BuildChannel channel) {
   }
 

--- a/src/main/java/io/papermc/fill/notification/WebhookPayload.java
+++ b/src/main/java/io/papermc/fill/notification/WebhookPayload.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 PaperMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.papermc.fill.notification;
+
+import io.papermc.fill.event.FillEvent;
+import java.time.Instant;
+import org.jspecify.annotations.NullMarked;
+
+/** The payload delivered for a {@link FillEvent}. */
+@NullMarked
+public record WebhookPayload(String type, Instant timestamp, Data data) {
+
+  public sealed interface Data permits Data.BuildPublished, Data.BuildPromoted, Data.VersionCreated, Data.VersionUpdated {
+    record BuildPublished(ProjectRef project, VersionRef version, BuildRef build) implements Data {
+    }
+
+    record BuildPromoted(ProjectRef project, VersionRef version, BuildRef build) implements Data {
+    }
+
+    record VersionCreated(ProjectRef project, VersionRef version) implements Data {
+    }
+
+    record VersionUpdated(ProjectRef project, VersionRef version) implements Data {
+    }
+  }
+
+  public record ProjectRef(String id, String key) {
+  }
+
+  public record VersionRef(String id, String key) {
+  }
+
+  public record BuildRef(String id, int number, String channel) {
+  }
+
+  public static WebhookPayload from(final FillEvent event) {
+    final ProjectRef project = new ProjectRef(event.project().id(), event.project().key());
+    final VersionRef version = new VersionRef(event.version().id(), event.version().key());
+    final Data data = switch (event) {
+      case FillEvent.BuildPublished e -> new Data.BuildPublished(
+        project,
+        version,
+        new BuildRef(e.build().id(), e.build().number(), e.build().channel().name())
+      );
+      case FillEvent.BuildPromoted e -> new Data.BuildPromoted(
+        project,
+        version,
+        new BuildRef(e.build().id(), e.build().number(), e.build().channel().name())
+      );
+      case FillEvent.VersionCreated _ -> new Data.VersionCreated(project, version);
+      case FillEvent.VersionUpdated _ -> new Data.VersionUpdated(project, version);
+    };
+    return new WebhookPayload(event.type(), event.time(), data);
+  }
+}

--- a/src/main/java/io/papermc/fill/notification/WebhookPayload.java
+++ b/src/main/java/io/papermc/fill/notification/WebhookPayload.java
@@ -25,7 +25,7 @@ import org.jspecify.annotations.NullMarked;
 public record WebhookPayload(String type, Instant timestamp, Data data) {
 
   @NullMarked
-  public sealed interface Data permits Data.BuildPublished, Data.BuildPromoted, Data.VersionCreated, Data.VersionUpdated {
+  public sealed interface Data permits Data.BuildPublished, Data.BuildPromoted, Data.VersionCreated, Data.VersionUpdated, Data.FamilyCreated, Data.FamilyUpdated, Data.FamilyDeleted {
     @NullMarked
     record BuildPublished(ProjectRef project, VersionRef version, BuildRef build) implements Data {
     }
@@ -41,6 +41,18 @@ public record WebhookPayload(String type, Instant timestamp, Data data) {
     @NullMarked
     record VersionUpdated(ProjectRef project, VersionRef version) implements Data {
     }
+
+    @NullMarked
+    record FamilyCreated(ProjectRef project, FamilyRef family) implements Data {
+    }
+
+    @NullMarked
+    record FamilyUpdated(ProjectRef project, FamilyRef family) implements Data {
+    }
+
+    @NullMarked
+    record FamilyDeleted(ProjectRef project, FamilyRef family) implements Data {
+    }
   }
 
   @NullMarked
@@ -52,26 +64,43 @@ public record WebhookPayload(String type, Instant timestamp, Data data) {
   }
 
   @NullMarked
+  public record FamilyRef(String id, String key) {
+  }
+
+  @NullMarked
   public record BuildRef(String id, int number, BuildChannel channel) {
   }
 
   public static WebhookPayload from(final FillEvent event) {
-    final ProjectRef project = new ProjectRef(event.project().id(), event.project().key());
-    final VersionRef version = new VersionRef(event.version().id(), event.version().key());
     final Data data = switch (event) {
       case FillEvent.BuildPublished e -> new Data.BuildPublished(
-        project,
-        version,
+        project(e),
+        version(e),
         new BuildRef(e.build().id(), e.build().number(), e.build().channel())
       );
       case FillEvent.BuildPromoted e -> new Data.BuildPromoted(
-        project,
-        version,
+        project(e),
+        version(e),
         new BuildRef(e.build().id(), e.build().number(), e.build().channel())
       );
-      case FillEvent.VersionCreated _ -> new Data.VersionCreated(project, version);
-      case FillEvent.VersionUpdated _ -> new Data.VersionUpdated(project, version);
+      case FillEvent.VersionCreated e -> new Data.VersionCreated(project(e), version(e));
+      case FillEvent.VersionUpdated e -> new Data.VersionUpdated(project(e), version(e));
+      case FillEvent.FamilyCreated e -> new Data.FamilyCreated(project(e), family(e));
+      case FillEvent.FamilyUpdated e -> new Data.FamilyUpdated(project(e), family(e));
+      case FillEvent.FamilyDeleted e -> new Data.FamilyDeleted(project(e), family(e));
     };
     return new WebhookPayload(event.type(), event.time(), data);
+  }
+
+  private static ProjectRef project(final FillEvent.ProjectEvent event) {
+    return new ProjectRef(event.project().id(), event.project().key());
+  }
+
+  private static VersionRef version(final FillEvent.VersionEvent event) {
+    return new VersionRef(event.version().id(), event.version().key());
+  }
+
+  private static FamilyRef family(final FillEvent.FamilyEvent event) {
+    return new FamilyRef(event.family().id(), event.family().key());
   }
 }

--- a/src/main/java/io/papermc/fill/notification/WebhookPayload.java
+++ b/src/main/java/io/papermc/fill/notification/WebhookPayload.java
@@ -23,7 +23,6 @@ import org.jspecify.annotations.NullMarked;
 /** The payload delivered for a {@link FillEvent}. */
 @NullMarked
 public record WebhookPayload(String type, Instant timestamp, Data data) {
-
   @NullMarked
   public sealed interface Data permits Data.BuildPublished, Data.BuildPromoted, Data.VersionCreated, Data.VersionUpdated, Data.FamilyCreated, Data.FamilyUpdated, Data.FamilyDeleted {
     @NullMarked

--- a/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
+++ b/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
@@ -249,5 +249,4 @@ public class WebhookPublisher {
       return this.status;
     }
   }
-
 }

--- a/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
+++ b/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
@@ -25,18 +25,16 @@ import io.papermc.fill.service.WebhookService;
 import jakarta.annotation.PreDestroy;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
+import java.time.Clock;
 import java.time.Duration;
-import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Semaphore;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.jspecify.annotations.NullMarked;
@@ -44,10 +42,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.retry.RetryException;
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryTemplate;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
 /**
@@ -59,7 +62,7 @@ import org.springframework.web.client.RestClient;
  * using the webhook's own secret, and retried with exponential backoff.</p>
  *
  * <p>Events are notifications, not data: consumers are expected to refetch the affected
- * resources from the API after verifying a delivery.</p>
+ * resources from the API after verifying a delivery. Events may be delivered out of order.</p>
  */
 @Component
 @NullMarked
@@ -72,20 +75,28 @@ public class WebhookPublisher {
   private static final Duration READ_TIMEOUT = Duration.ofSeconds(10);
 
   private final WebhookService webhooks;
+  private final Clock clock;
   private final ObjectMapper json;
   private final RestClient http;
-  private final ExecutorService executor = new ThreadPoolExecutor(
-    MAX_CONCURRENT_DELIVERIES,
-    MAX_CONCURRENT_DELIVERIES,
-    0L,
-    TimeUnit.MILLISECONDS,
-    new ArrayBlockingQueue<>(MAX_QUEUED_DELIVERIES),
+  private final RetryTemplate retry = new RetryTemplate(RetryPolicy.builder()
+    .maxRetries(MAX_ATTEMPTS - 1)
+    .delay(Duration.ofSeconds(1))
+    .jitter(Duration.ofMillis(250))
+    .multiplier(2)
+    .maxDelay(Duration.ofSeconds(8))
+    .excludes(Error.class)
+    .predicate(WebhookPublisher::isRetryable)
+    .build());
+  private final ExecutorService executor = Executors.newThreadPerTaskExecutor(
     Thread.ofVirtual().name("webhook-delivery-", 0).factory()
   );
+  private final Semaphore admission = new Semaphore(MAX_CONCURRENT_DELIVERIES + MAX_QUEUED_DELIVERIES);
+  private final Semaphore concurrency = new Semaphore(MAX_CONCURRENT_DELIVERIES);
 
   @Autowired
-  public WebhookPublisher(final WebhookService webhooks) {
+  public WebhookPublisher(final WebhookService webhooks, final Clock clock) {
     this.webhooks = webhooks;
+    this.clock = clock;
     this.json = new ObjectMapper();
     final SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
     requestFactory.setConnectTimeout(CONNECT_TIMEOUT);
@@ -106,10 +117,27 @@ public class WebhookPublisher {
       return;
     }
     for (final WebhookEntity webhook : targets) {
-      try {
-        this.executor.submit(() -> this.deliver(webhook, event));
-      } catch (final RejectedExecutionException exception) {
+      if (!this.admission.tryAcquire()) {
         LOGGER.warn("Webhook delivery queue is full; dropping {} event for {}", event.type(), webhook.url());
+        continue;
+      }
+      try {
+        this.executor.execute(() -> {
+          try {
+            this.concurrency.acquire();
+            try {
+              this.deliver(webhook, event);
+            } finally {
+              this.concurrency.release();
+            }
+          } catch (final InterruptedException exception) {
+            Thread.currentThread().interrupt();
+          } finally {
+            this.admission.release();
+          }
+        });
+      } catch (final RejectedExecutionException exception) {
+        this.admission.release();
       }
     }
   }
@@ -121,7 +149,7 @@ public class WebhookPublisher {
 
   private void deliver(final WebhookEntity webhook, final FillEvent event) {
     final String deliveryId = "fill_" + UUID.randomUUID();
-    final String timestamp = Long.toString(Instant.now().getEpochSecond());
+    final String timestamp = Long.toString(this.clock.instant().getEpochSecond());
 
     final byte[] body;
     final String signature;
@@ -134,9 +162,8 @@ public class WebhookPublisher {
       return;
     }
 
-    Exception lastFailure = null;
-    for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-      try {
+    try {
+      this.retry.execute(() -> {
         this.http.post()
           .uri(webhook.url())
           .contentType(MediaType.APPLICATION_JSON)
@@ -146,28 +173,34 @@ public class WebhookPublisher {
           .body(body)
           .retrieve()
           .toBodilessEntity();
-        this.webhooks.recordDelivery(webhook, "delivered");
+        return null;
+      });
+      this.webhooks.recordDelivery(webhook, "delivered");
+    } catch (final RetryException exception) {
+      if (Thread.currentThread().isInterrupted()) {
+        // Shutdown interrupted the delivery; leave its previous status unchanged.
         return;
-      } catch (final Exception exception) {
-        lastFailure = exception;
-        if (attempt < MAX_ATTEMPTS) {
-          LOGGER.warn(
-            "Failed to deliver webhook {} to {} (attempt {}/{}): {}",
-            deliveryId,
-            webhook.url(),
-            attempt,
-            MAX_ATTEMPTS,
-            exception.getMessage()
-          );
-          if (!sleep(attempt)) {
-            return;
-          }
-        }
       }
+      if (exception.getLastException() instanceof final Error error) {
+        throw error;
+      }
+      LOGGER.error(
+        "Giving up on webhook delivery {} to {} after {} attempts",
+        deliveryId,
+        webhook.url(),
+        exception.getExceptions().size(),
+        exception
+      );
+      this.webhooks.recordDelivery(webhook, "failed");
     }
+  }
 
-    LOGGER.error("Giving up on webhook delivery {} to {} after {} attempts", deliveryId, webhook.url(), MAX_ATTEMPTS, lastFailure);
-    this.webhooks.recordDelivery(webhook, "failed");
+  private static boolean isRetryable(final Throwable failure) {
+    if (failure instanceof final HttpClientErrorException exception) {
+      return exception.getStatusCode() == HttpStatus.REQUEST_TIMEOUT
+        || exception.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS;
+    }
+    return true;
   }
 
   private byte[] createPayload(final FillEvent event) {
@@ -216,14 +249,4 @@ public class WebhookPublisher {
     }
   }
 
-  private static boolean sleep(final int attempt) {
-    try {
-      final long millis = (long) Math.pow(2.0, attempt - 1) * 1000L + ThreadLocalRandom.current().nextLong(250L);
-      Thread.sleep(millis);
-      return true;
-    } catch (final InterruptedException exception) {
-      Thread.currentThread().interrupt();
-      return false;
-    }
-  }
 }

--- a/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
+++ b/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
@@ -236,6 +236,7 @@ public class WebhookPublisher {
     }
   }
 
+  @NullMarked
   private static final class NonSuccessfulDelivery extends RuntimeException {
     private final HttpStatusCode status;
 

--- a/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
+++ b/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
@@ -22,6 +22,7 @@ import io.papermc.fill.database.WebhookEntity;
 import io.papermc.fill.event.FillEvent;
 import io.papermc.fill.model.DeliveryStatus;
 import io.papermc.fill.service.WebhookService;
+import io.papermc.fill.util.concurrent.ConcurrentUtil;
 import jakarta.annotation.PreDestroy;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
@@ -72,6 +73,7 @@ public class WebhookPublisher {
   private static final int MAX_QUEUED_DELIVERIES = 256;
   private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
   private static final Duration READ_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
 
   private final WebhookService webhooks;
   private final Clock clock;
@@ -143,7 +145,7 @@ public class WebhookPublisher {
 
   @PreDestroy
   public void close() {
-    this.executor.shutdownNow();
+    ConcurrentUtil.shutdownExecutor(this.executor, SHUTDOWN_TIMEOUT);
   }
 
   private void deliver(final WebhookEntity webhook, final FillEvent event) {

--- a/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
+++ b/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2024 PaperMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.papermc.fill.notification;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
+import io.papermc.fill.database.WebhookEntity;
+import io.papermc.fill.event.FillEvent;
+import io.papermc.fill.service.WebhookService;
+import jakarta.annotation.PreDestroy;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Delivers {@link FillEvent}s to registered webhook endpoints.
+ *
+ * <p>Deliveries follow the
+ * <a href="https://www.standardwebhooks.com/spec/">Standard Webhooks</a> specification:
+ * each delivery is signed with an HMAC-SHA256 over {@code webhook-id + "." + webhook-timestamp + "." + body}
+ * using the webhook's own secret, and retried with exponential backoff.</p>
+ *
+ * <p>Events are notifications, not data: consumers are expected to refetch the affected
+ * resources from the API after verifying a delivery.</p>
+ */
+@Component
+@NullMarked
+public class WebhookPublisher {
+  private static final Logger LOGGER = LoggerFactory.getLogger(WebhookPublisher.class);
+  private static final int MAX_ATTEMPTS = 5;
+  private static final int MAX_CONCURRENT_DELIVERIES = 16;
+  private static final int MAX_QUEUED_DELIVERIES = 256;
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+  private static final Duration READ_TIMEOUT = Duration.ofSeconds(10);
+
+  private final WebhookService webhooks;
+  private final ObjectMapper json;
+  private final RestClient http;
+  private final ExecutorService executor = new ThreadPoolExecutor(
+    MAX_CONCURRENT_DELIVERIES,
+    MAX_CONCURRENT_DELIVERIES,
+    0L,
+    TimeUnit.MILLISECONDS,
+    new ArrayBlockingQueue<>(MAX_QUEUED_DELIVERIES),
+    Thread.ofVirtual().name("webhook-delivery-", 0).factory()
+  );
+
+  @Autowired
+  public WebhookPublisher(final WebhookService webhooks) {
+    this.webhooks = webhooks;
+    this.json = new ObjectMapper();
+    final SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+    requestFactory.setConnectTimeout(CONNECT_TIMEOUT);
+    requestFactory.setReadTimeout(READ_TIMEOUT);
+    this.http = RestClient.builder()
+      .requestFactory(requestFactory)
+      .defaultHeader(HttpHeaders.USER_AGENT, "Fill (Webhooks)")
+      .build();
+  }
+
+  @EventListener
+  public void onFillEvent(final FillEvent event) {
+    final List<WebhookEntity> targets;
+    try {
+      targets = this.webhooks.list();
+    } catch (final Exception exception) {
+      LOGGER.warn("Failed to list webhooks for event {}", event.type(), exception);
+      return;
+    }
+    for (final WebhookEntity webhook : targets) {
+      try {
+        this.executor.submit(() -> this.deliver(webhook, event));
+      } catch (final RejectedExecutionException exception) {
+        LOGGER.warn("Webhook delivery queue is full; dropping {} event for {}", event.type(), webhook.url());
+      }
+    }
+  }
+
+  @PreDestroy
+  public void close() {
+    this.executor.shutdownNow();
+  }
+
+  private void deliver(final WebhookEntity webhook, final FillEvent event) {
+    final String deliveryId = "fill_" + UUID.randomUUID();
+    final String timestamp = Long.toString(Instant.now().getEpochSecond());
+    final byte[] body = this.createPayload(event);
+    final String signature = createSignature(webhook.secret(), deliveryId, timestamp, body);
+
+    Exception lastFailure = null;
+    for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        this.http.post()
+          .uri(webhook.url())
+          .contentType(MediaType.APPLICATION_JSON)
+          .header("webhook-id", deliveryId)
+          .header("webhook-timestamp", timestamp)
+          .header("webhook-signature", signature)
+          .body(body)
+          .retrieve()
+          .toBodilessEntity();
+        this.webhooks.recordDelivery(webhook, "delivered");
+        return;
+      } catch (final Exception exception) {
+        lastFailure = exception;
+        if (attempt < MAX_ATTEMPTS) {
+          LOGGER.warn(
+            "Failed to deliver webhook {} to {} (attempt {}/{}): {}",
+            deliveryId,
+            webhook.url(),
+            attempt,
+            MAX_ATTEMPTS,
+            exception.getMessage()
+          );
+          if (!sleep(attempt)) {
+            return;
+          }
+        }
+      }
+    }
+
+    LOGGER.error("Giving up on webhook delivery {} to {} after {} attempts", deliveryId, webhook.url(), MAX_ATTEMPTS, lastFailure);
+    this.webhooks.recordDelivery(webhook, "failed");
+  }
+
+  private byte[] createPayload(final FillEvent event) {
+    final ObjectNode root = this.json.createObjectNode();
+    root.put("type", event.type());
+    root.put("timestamp", DateTimeFormatter.ISO_INSTANT.format(event.time()));
+    final ObjectNode data = root.putObject("data");
+    data.put("project", event.project().key());
+    data.put("version", event.version().key());
+    switch (event) {
+      case FillEvent.BuildPublished published -> {
+        data.put("build", published.build().number());
+        data.put("channel", published.build().channel().name());
+      }
+      case FillEvent.BuildPromoted promoted -> {
+        data.put("build", promoted.build().number());
+        data.put("channel", promoted.build().channel().name());
+      }
+      case FillEvent.VersionCreated _, FillEvent.VersionUpdated _ -> {
+      }
+    }
+    try {
+      return this.json.writeValueAsBytes(root);
+    } catch (final JsonProcessingException exception) {
+      throw new IllegalStateException("Could not serialize webhook payload", exception);
+    }
+  }
+
+  @VisibleForTesting
+  static String createSignature(final String secret, final String deliveryId, final String timestamp, final byte[] body) {
+    try {
+      final Mac mac = Mac.getInstance("HmacSHA256");
+      if (!secret.startsWith("whsec_")) {
+        throw new IllegalArgumentException("Invalid webhook secret prefix");
+      }
+      final byte[] key = Base64.getDecoder().decode(secret.substring("whsec_".length()));
+      mac.init(new SecretKeySpec(key, "HmacSHA256"));
+      mac.update(deliveryId.getBytes(StandardCharsets.UTF_8));
+      mac.update((byte) '.');
+      mac.update(timestamp.getBytes(StandardCharsets.UTF_8));
+      mac.update((byte) '.');
+      mac.update(body);
+      return "v1," + Base64.getEncoder().encodeToString(mac.doFinal());
+    } catch (final GeneralSecurityException exception) {
+      throw new IllegalStateException("Could not create webhook signature", exception);
+    }
+  }
+
+  private static boolean sleep(final int attempt) {
+    try {
+      final long millis = (long) Math.pow(2.0, attempt - 1) * 1000L + ThreadLocalRandom.current().nextLong(250L);
+      Thread.sleep(millis);
+      return true;
+    } catch (final InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+}

--- a/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
+++ b/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import io.papermc.fill.database.WebhookEntity;
 import io.papermc.fill.event.FillEvent;
+import io.papermc.fill.model.DeliveryStatus;
 import io.papermc.fill.service.WebhookService;
 import jakarta.annotation.PreDestroy;
 import java.nio.charset.StandardCharsets;
@@ -156,7 +157,7 @@ public class WebhookPublisher {
       signature = createSignature(webhook.secret(), deliveryId, timestamp, body);
     } catch (final Exception exception) {
       LOGGER.error("Failed to prepare webhook delivery {} to {}", deliveryId, webhook.url(), exception);
-      this.webhooks.recordDelivery(webhook, "failed");
+      this.webhooks.recordDelivery(webhook, DeliveryStatus.FAILED);
       return;
     }
 
@@ -173,7 +174,7 @@ public class WebhookPublisher {
           .toBodilessEntity();
         return null;
       });
-      this.webhooks.recordDelivery(webhook, "delivered");
+      this.webhooks.recordDelivery(webhook, DeliveryStatus.DELIVERED);
     } catch (final RetryException exception) {
       if (Thread.currentThread().isInterrupted()) {
         // Shutdown interrupted the delivery; leave its previous status unchanged.
@@ -189,7 +190,7 @@ public class WebhookPublisher {
         exception.getExceptions().size(),
         exception
       );
-      this.webhooks.recordDelivery(webhook, "failed");
+      this.webhooks.recordDelivery(webhook, DeliveryStatus.FAILED);
     }
   }
 

--- a/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
+++ b/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
@@ -46,10 +46,10 @@ import org.springframework.core.retry.RetryPolicy;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
 /**
@@ -170,8 +170,12 @@ public class WebhookPublisher {
           .header("webhook-timestamp", timestamp)
           .header("webhook-signature", signature)
           .body(body)
-          .retrieve()
-          .toBodilessEntity();
+          .exchange((request, response) -> {
+            if (!response.getStatusCode().is2xxSuccessful()) {
+              throw new NonSuccessfulDelivery(response.getStatusCode());
+            }
+            return null;
+          });
         return null;
       });
       this.webhooks.recordDelivery(webhook, DeliveryStatus.DELIVERED);
@@ -195,9 +199,11 @@ public class WebhookPublisher {
   }
 
   private static boolean isRetryable(final Throwable failure) {
-    if (failure instanceof final HttpClientErrorException exception) {
-      return exception.getStatusCode() == HttpStatus.REQUEST_TIMEOUT
-        || exception.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS;
+    if (failure instanceof final NonSuccessfulDelivery exception) {
+      final HttpStatusCode status = exception.status();
+      return status.is5xxServerError()
+        || status.isSameCodeAs(HttpStatus.REQUEST_TIMEOUT)
+        || status.isSameCodeAs(HttpStatus.TOO_MANY_REQUESTS);
     }
     return true;
   }
@@ -227,6 +233,19 @@ public class WebhookPublisher {
       return "v1," + Base64.getEncoder().encodeToString(mac.doFinal());
     } catch (final GeneralSecurityException exception) {
       throw new IllegalStateException("Could not create webhook signature", exception);
+    }
+  }
+
+  private static final class NonSuccessfulDelivery extends RuntimeException {
+    private final HttpStatusCode status;
+
+    private NonSuccessfulDelivery(final HttpStatusCode status) {
+      super("Webhook target responded with status " + status.value());
+      this.status = status;
+    }
+
+    private HttpStatusCode status() {
+      return this.status;
     }
   }
 

--- a/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
+++ b/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
@@ -17,7 +17,6 @@ package io.papermc.fill.notification;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import io.papermc.fill.database.WebhookEntity;
 import io.papermc.fill.event.FillEvent;
@@ -27,7 +26,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.time.Clock;
 import java.time.Duration;
-import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
@@ -94,10 +92,10 @@ public class WebhookPublisher {
   private final Semaphore concurrency = new Semaphore(MAX_CONCURRENT_DELIVERIES);
 
   @Autowired
-  public WebhookPublisher(final WebhookService webhooks, final Clock clock) {
+  public WebhookPublisher(final WebhookService webhooks, final Clock clock, final ObjectMapper json) {
     this.webhooks = webhooks;
     this.clock = clock;
-    this.json = new ObjectMapper();
+    this.json = json;
     final SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
     requestFactory.setConnectTimeout(CONNECT_TIMEOUT);
     requestFactory.setReadTimeout(READ_TIMEOUT);
@@ -204,26 +202,8 @@ public class WebhookPublisher {
   }
 
   private byte[] createPayload(final FillEvent event) {
-    final ObjectNode root = this.json.createObjectNode();
-    root.put("type", event.type());
-    root.put("timestamp", DateTimeFormatter.ISO_INSTANT.format(event.time()));
-    final ObjectNode data = root.putObject("data");
-    data.put("project", event.project().key());
-    data.put("version", event.version().key());
-    switch (event) {
-      case FillEvent.BuildPublished published -> {
-        data.put("build", published.build().number());
-        data.put("channel", published.build().channel().name());
-      }
-      case FillEvent.BuildPromoted promoted -> {
-        data.put("build", promoted.build().number());
-        data.put("channel", promoted.build().channel().name());
-      }
-      case FillEvent.VersionCreated _, FillEvent.VersionUpdated _ -> {
-      }
-    }
     try {
-      return this.json.writeValueAsBytes(root);
+      return this.json.writeValueAsBytes(WebhookPayload.from(event));
     } catch (final JsonProcessingException exception) {
       throw new IllegalStateException("Could not serialize webhook payload", exception);
     }

--- a/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
+++ b/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
@@ -122,8 +122,17 @@ public class WebhookPublisher {
   private void deliver(final WebhookEntity webhook, final FillEvent event) {
     final String deliveryId = "fill_" + UUID.randomUUID();
     final String timestamp = Long.toString(Instant.now().getEpochSecond());
-    final byte[] body = this.createPayload(event);
-    final String signature = createSignature(webhook.secret(), deliveryId, timestamp, body);
+
+    final byte[] body;
+    final String signature;
+    try {
+      body = this.createPayload(event);
+      signature = createSignature(webhook.secret(), deliveryId, timestamp, body);
+    } catch (final Exception exception) {
+      LOGGER.error("Failed to prepare webhook delivery {} to {}", deliveryId, webhook.url(), exception);
+      this.webhooks.recordDelivery(webhook, "failed");
+      return;
+    }
 
     Exception lastFailure = null;
     for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {

--- a/src/main/java/io/papermc/fill/service/WebhookService.java
+++ b/src/main/java/io/papermc/fill/service/WebhookService.java
@@ -18,6 +18,7 @@ package io.papermc.fill.service;
 import io.papermc.fill.database.WebhookEntity;
 import io.papermc.fill.database.WebhookRepository;
 import io.papermc.fill.exception.WebhookNotFoundException;
+import io.papermc.fill.model.DeliveryStatus;
 import io.papermc.fill.model.Timestamped;
 import java.security.SecureRandom;
 import java.time.Clock;
@@ -80,7 +81,7 @@ public class WebhookService {
   // Note: auto-pausing a webhook after N consecutive failed deliveries would be a useful
   // follow-up. Deferred for now - failures are logged and observable, so repeated failures
   // can be noticed and the webhook deleted manually.
-  public void recordDelivery(final WebhookEntity webhook, final String status) {
+  public void recordDelivery(final WebhookEntity webhook, final DeliveryStatus status) {
     try {
       // Best-effort: a 0-match update (webhook deleted mid-flight) is acceptable and ignored.
       this.webhooks.updateDelivery(webhook._id(), status, this.clock.instant());

--- a/src/main/java/io/papermc/fill/service/WebhookService.java
+++ b/src/main/java/io/papermc/fill/service/WebhookService.java
@@ -77,6 +77,9 @@ public class WebhookService {
       .toList();
   }
 
+  // Note: auto-pausing a webhook after N consecutive failed deliveries would be a useful
+  // follow-up. Deferred for now - failures are logged and observable, so repeated failures
+  // can be noticed and the webhook deleted manually.
   public void recordDelivery(final WebhookEntity webhook, final String status) {
     try {
       // Best-effort: a 0-match update (webhook deleted mid-flight) is acceptable and ignored.

--- a/src/main/java/io/papermc/fill/service/WebhookService.java
+++ b/src/main/java/io/papermc/fill/service/WebhookService.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 PaperMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.papermc.fill.service;
+
+import io.papermc.fill.database.WebhookEntity;
+import io.papermc.fill.database.WebhookRepository;
+import io.papermc.fill.exception.WebhookNotFoundException;
+import io.papermc.fill.model.Timestamped;
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import org.bson.types.ObjectId;
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+@NullMarked
+public class WebhookService {
+  private static final Logger LOGGER = LoggerFactory.getLogger(WebhookService.class);
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private final WebhookRepository webhooks;
+  private final Clock clock;
+
+  @Autowired
+  public WebhookService(final WebhookRepository webhooks, final Clock clock) {
+    this.webhooks = webhooks;
+    this.clock = clock;
+  }
+
+  public WebhookEntity create(final String url) {
+    final Instant createdAt = this.clock.instant();
+    final WebhookEntity entity = WebhookEntity.create(
+      new ObjectId(Date.from(createdAt)),
+      createdAt,
+      url,
+      generateSecret()
+    );
+    return this.webhooks.save(entity);
+  }
+
+  public boolean delete(final String id) {
+    if (!ObjectId.isValid(id)) {
+      throw new WebhookNotFoundException();
+    }
+    final ObjectId objectId = new ObjectId(id);
+    if (!this.webhooks.existsById(objectId)) {
+      throw new WebhookNotFoundException();
+    }
+    this.webhooks.deleteById(objectId);
+    return true;
+  }
+
+  public List<WebhookEntity> list() {
+    return this.webhooks.findAll()
+      .stream()
+      .sorted(Timestamped.CREATED_AT_ASC)
+      .toList();
+  }
+
+  public void recordDelivery(final WebhookEntity webhook, final String status) {
+    try {
+      this.webhooks.updateDelivery(webhook._id(), status, this.clock.instant());
+    } catch (final Exception exception) {
+      LOGGER.warn("Failed to record delivery status for webhook {}", webhook.id(), exception);
+    }
+  }
+
+  private static String generateSecret() {
+    final byte[] bytes = new byte[32];
+    RANDOM.nextBytes(bytes);
+    return "whsec_" + Base64.getEncoder().encodeToString(bytes);
+  }
+}

--- a/src/main/java/io/papermc/fill/service/WebhookService.java
+++ b/src/main/java/io/papermc/fill/service/WebhookService.java
@@ -79,6 +79,7 @@ public class WebhookService {
 
   public void recordDelivery(final WebhookEntity webhook, final String status) {
     try {
+      // Best-effort: a 0-match update (webhook deleted mid-flight) is acceptable and ignored.
       this.webhooks.updateDelivery(webhook._id(), status, this.clock.instant());
     } catch (final Exception exception) {
       LOGGER.warn("Failed to record delivery status for webhook {}", webhook.id(), exception);

--- a/src/main/java/io/papermc/fill/util/concurrent/ConcurrentUtil.java
+++ b/src/main/java/io/papermc/fill/util/concurrent/ConcurrentUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 PaperMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.papermc.fill.util.concurrent;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public final class ConcurrentUtil {
+  private ConcurrentUtil() {
+  }
+
+  /**
+   * Attempts a bounded graceful shutdown of the given executor, falling back to an
+   * immediate forced shutdown if the timeout elapses before all tasks complete.
+   *
+   * @param service the executor to shut down
+   * @param timeout how long to wait for graceful termination before forcing it
+   */
+  public static void shutdownExecutor(final ExecutorService service, final Duration timeout) {
+    shutdownExecutor(service, TimeUnit.NANOSECONDS, timeout.toNanos());
+  }
+
+  /**
+   * Attempts a bounded graceful shutdown of the given executor, falling back to an
+   * immediate forced shutdown if the timeout elapses before all tasks complete.
+   *
+   * @param service the executor to shut down
+   * @param timeoutUnit the unit of {@code timeoutLength}
+   * @param timeoutLength how long to wait for graceful termination before forcing it
+   */
+  public static void shutdownExecutor(final ExecutorService service, final TimeUnit timeoutUnit, final long timeoutLength) {
+    service.shutdown();
+    boolean didShutdown;
+    try {
+      didShutdown = service.awaitTermination(timeoutLength, timeoutUnit);
+    } catch (final InterruptedException ignore) {
+      didShutdown = false;
+    }
+    if (!didShutdown) {
+      service.shutdownNow();
+    }
+  }
+}

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -223,6 +223,12 @@ enum BuildChannel {
   RECOMMENDED
 }
 
+enum DeliveryStatus {
+  DELIVERED
+
+  FAILED
+}
+
 type Webhook {
   id: ID!
 
@@ -230,7 +236,7 @@ type Webhook {
 
   createdAt: DateTime!
 
-  lastDeliveryStatus: String
+  lastDeliveryStatus: DeliveryStatus
 
   lastDeliveryAt: DateTime
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -7,6 +7,8 @@ type Query {
   project(
     key: String!
   ): Project
+
+  webhooks: [Webhook]
 }
 
 type Mutation {
@@ -37,6 +39,14 @@ type Mutation {
   promoteBuild(
     input: PromoteBuildInput!
   ): PromoteBuildPayload
+
+  createWebhook(
+    input: CreateWebhookInput!
+  ): CreateWebhookPayload
+
+  deleteWebhook(
+    input: DeleteWebhookInput!
+  ): DeleteWebhookPayload
 }
 
 interface Node {
@@ -213,6 +223,18 @@ enum BuildChannel {
   RECOMMENDED
 }
 
+type Webhook {
+  id: ID!
+
+  url: String!
+
+  createdAt: DateTime!
+
+  lastDeliveryStatus: String
+
+  lastDeliveryAt: DateTime
+}
+
 type Checksums {
   sha256: String!
 }
@@ -327,6 +349,14 @@ input DeleteVersionInput {
   key: String!
 }
 
+input CreateWebhookInput {
+  url: String!
+}
+
+input DeleteWebhookInput {
+  id: ID!
+}
+
 type CreateVersionPayload {
   version: Version
 }
@@ -336,6 +366,16 @@ type UpdateVersionPayload {
 }
 
 type DeleteVersionPayload {
+  ok: Boolean!
+}
+
+type CreateWebhookPayload {
+  webhook: Webhook!
+
+  secret: String!
+}
+
+type DeleteWebhookPayload {
   ok: Boolean!
 }
 

--- a/src/test/java/io/papermc/fill/controller/Publishing3ControllerTest.java
+++ b/src/test/java/io/papermc/fill/controller/Publishing3ControllerTest.java
@@ -23,6 +23,7 @@ import io.papermc.fill.database.ProjectEntity;
 import io.papermc.fill.database.ProjectRepository;
 import io.papermc.fill.database.VersionEntity;
 import io.papermc.fill.database.VersionRepository;
+import io.papermc.fill.event.AsyncEventPublisher;
 import io.papermc.fill.event.FillEvent;
 import io.papermc.fill.exception.PublishFailedException;
 import io.papermc.fill.exception.StorageWriteException;
@@ -50,7 +51,6 @@ import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -103,7 +103,7 @@ public class Publishing3ControllerTest {
   private VersionRepository versions;
   private BuildRepository builds;
   private StorageService storage;
-  private ApplicationEventPublisher events;
+  private AsyncEventPublisher events;
   private Publishing3Controller controller;
 
   @BeforeEach
@@ -113,7 +113,7 @@ public class Publishing3ControllerTest {
     this.versions = mock(VersionRepository.class);
     this.builds = mock(BuildRepository.class);
     this.storage = mock(StorageService.class);
-    this.events = mock(ApplicationEventPublisher.class);
+    this.events = mock(AsyncEventPublisher.class);
     this.controller = new Publishing3Controller(
       this.projects,
       this.families,
@@ -149,7 +149,7 @@ public class Publishing3ControllerTest {
     for (final Download download : downloads) {
       order.verify(this.storage).deleteStagedObject(UPLOAD_ID, download.name());
     }
-    order.verify(this.events).publishEvent(any(FillEvent.BuildPublished.class));
+    order.verify(this.events).publish(any(FillEvent.BuildPublished.class));
   }
 
   @Test
@@ -164,9 +164,9 @@ public class Publishing3ControllerTest {
 
     final InOrder order = inOrder(this.versions, this.builds, this.events);
     order.verify(this.versions).save(any(VersionEntity.class));
-    order.verify(this.events).publishEvent(any(FillEvent.VersionCreated.class));
+    order.verify(this.events).publish(any(FillEvent.VersionCreated.class));
     order.verify(this.builds).save(any(BuildEntity.class));
-    order.verify(this.events).publishEvent(any(FillEvent.BuildPublished.class));
+    order.verify(this.events).publish(any(FillEvent.BuildPublished.class));
   }
 
   @Test

--- a/src/test/java/io/papermc/fill/controller/Publishing3ControllerTest.java
+++ b/src/test/java/io/papermc/fill/controller/Publishing3ControllerTest.java
@@ -23,6 +23,7 @@ import io.papermc.fill.database.ProjectEntity;
 import io.papermc.fill.database.ProjectRepository;
 import io.papermc.fill.database.VersionEntity;
 import io.papermc.fill.database.VersionRepository;
+import io.papermc.fill.event.FillEvent;
 import io.papermc.fill.exception.PublishFailedException;
 import io.papermc.fill.exception.StorageWriteException;
 import io.papermc.fill.model.BuildChannel;
@@ -34,7 +35,6 @@ import io.papermc.fill.model.JavaFlags;
 import io.papermc.fill.model.JavaVersion;
 import io.papermc.fill.model.Support;
 import io.papermc.fill.model.request.v3.PublishRequest;
-import io.papermc.fill.notification.BuildListener;
 import io.papermc.fill.service.StorageService;
 import io.papermc.fill.util.discord.DiscordNotificationChannel;
 import io.papermc.fill.util.git.GitRepository;
@@ -44,13 +44,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import org.bson.types.ObjectId;
 import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -103,7 +103,7 @@ public class Publishing3ControllerTest {
   private VersionRepository versions;
   private BuildRepository builds;
   private StorageService storage;
-  private BuildListener listener;
+  private ApplicationEventPublisher events;
   private Publishing3Controller controller;
 
   @BeforeEach
@@ -113,14 +113,14 @@ public class Publishing3ControllerTest {
     this.versions = mock(VersionRepository.class);
     this.builds = mock(BuildRepository.class);
     this.storage = mock(StorageService.class);
-    this.listener = mock(BuildListener.class);
+    this.events = mock(ApplicationEventPublisher.class);
     this.controller = new Publishing3Controller(
       this.projects,
       this.families,
       this.versions,
       this.builds,
       this.storage,
-      Set.of(this.listener)
+      this.events
     );
 
     when(this.projects.findByKey(PROJECT.key())).thenReturn(Optional.of(PROJECT));
@@ -138,7 +138,7 @@ public class Publishing3ControllerTest {
     final ResponseEntity<?> response = this.controller.publish(request);
 
     assertEquals(HttpStatus.CREATED, response.getStatusCode());
-    final InOrder order = inOrder(this.storage, this.builds, this.listener);
+    final InOrder order = inOrder(this.storage, this.builds, this.events);
     for (final Download download : downloads) {
       order.verify(this.storage).verifyStagedObject(UPLOAD_ID, download);
     }
@@ -149,7 +149,24 @@ public class Publishing3ControllerTest {
     for (final Download download : downloads) {
       order.verify(this.storage).deleteStagedObject(UPLOAD_ID, download.name());
     }
-    order.verify(this.listener).onBuildPublished(eq(PROJECT), eq(VERSION), any(BuildEntity.class));
+    order.verify(this.events).publishEvent(any(FillEvent.BuildPublished.class));
+  }
+
+  @Test
+  void publishesVersionCreatedBeforeBuildPublishedWhenCreatingMissingVersion() {
+    final PublishRequest request = request();
+    when(this.versions.findByProjectAndKey(PROJECT, VERSION.key())).thenReturn(Optional.empty());
+    when(this.versions.save(any(VersionEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(this.builds.findByVersionAndNumber(any(VersionEntity.class), eq(request.build()))).thenReturn(Optional.empty());
+    when(this.builds.save(any(BuildEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    this.controller.publish(request);
+
+    final InOrder order = inOrder(this.versions, this.builds, this.events);
+    order.verify(this.versions).save(any(VersionEntity.class));
+    order.verify(this.events).publishEvent(any(FillEvent.VersionCreated.class));
+    order.verify(this.builds).save(any(BuildEntity.class));
+    order.verify(this.events).publishEvent(any(FillEvent.BuildPublished.class));
   }
 
   @Test
@@ -166,7 +183,7 @@ public class Publishing3ControllerTest {
     for (final Download download : downloads) {
       verify(this.storage, never()).deleteStagedObject(UPLOAD_ID, download.name());
     }
-    verifyNoInteractions(this.listener);
+    verifyNoInteractions(this.events);
   }
 
   @Test
@@ -192,7 +209,7 @@ public class Publishing3ControllerTest {
     }
     verifyNoMoreInteractions(this.storage);
     verify(this.builds, never()).save(any(BuildEntity.class));
-    verifyNoInteractions(this.listener);
+    verifyNoInteractions(this.events);
   }
 
   private static PublishRequest request() {

--- a/src/test/java/io/papermc/fill/notification/WebhookPublisherTest.java
+++ b/src/test/java/io/papermc/fill/notification/WebhookPublisherTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 PaperMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.papermc.fill.notification;
+
+import java.nio.charset.StandardCharsets;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@NullMarked
+class WebhookPublisherTest {
+  @Test
+  void signsWithDecodedStandardWebhookSecret() {
+    final String signature = WebhookPublisher.createSignature(
+      "whsec_AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
+      "fill_test",
+      "1700000000",
+      "{\"type\":\"build.published\"}".getBytes(StandardCharsets.UTF_8)
+    );
+
+    assertEquals("v1,gjBnzVZudyFih59/Knjh7oE1wC2z3CMPV2RkxEBJBQk=", signature);
+  }
+}

--- a/src/test/java/io/papermc/fill/service/WebhookServiceTest.java
+++ b/src/test/java/io/papermc/fill/service/WebhookServiceTest.java
@@ -17,6 +17,7 @@ package io.papermc.fill.service;
 
 import io.papermc.fill.database.WebhookEntity;
 import io.papermc.fill.database.WebhookRepository;
+import io.papermc.fill.model.DeliveryStatus;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -58,8 +59,8 @@ class WebhookServiceTest {
       "whsec_AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
     );
 
-    service.recordDelivery(webhook, "delivered");
+    service.recordDelivery(webhook, DeliveryStatus.DELIVERED);
 
-    verify(repository).updateDelivery(webhook._id(), "delivered", NOW);
+    verify(repository).updateDelivery(webhook._id(), DeliveryStatus.DELIVERED, NOW);
   }
 }

--- a/src/test/java/io/papermc/fill/service/WebhookServiceTest.java
+++ b/src/test/java/io/papermc/fill/service/WebhookServiceTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 PaperMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.papermc.fill.service;
+
+import io.papermc.fill.database.WebhookEntity;
+import io.papermc.fill.database.WebhookRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@NullMarked
+class WebhookServiceTest {
+  private static final Instant NOW = Instant.parse("2026-07-28T00:00:00Z");
+
+  @Test
+  void createsStandardWebhookSecret() {
+    final WebhookRepository repository = mock(WebhookRepository.class);
+    when(repository.save(any(WebhookEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    final WebhookService service = new WebhookService(repository, Clock.fixed(NOW, ZoneOffset.UTC));
+
+    final WebhookEntity webhook = service.create("https://example.com/webhook");
+
+    assertTrue(webhook.secret().startsWith("whsec_"));
+    assertEquals(32, Base64.getDecoder().decode(webhook.secret().substring("whsec_".length())).length);
+  }
+
+  @Test
+  void recordsDeliveryWithAnAtomicUpdate() {
+    final WebhookRepository repository = mock(WebhookRepository.class);
+    final WebhookService service = new WebhookService(repository, Clock.fixed(NOW, ZoneOffset.UTC));
+    final WebhookEntity webhook = WebhookEntity.create(
+      new org.bson.types.ObjectId("000000000000000000000001"),
+      NOW,
+      "https://example.com/webhook",
+      "whsec_AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
+    );
+
+    service.recordDelivery(webhook, "delivered");
+
+    verify(repository).updateDelivery(webhook._id(), "delivered", NOW);
+  }
+}


### PR DESCRIPTION
Add webhook notifications for build and version lifecycle events. These will allow the website’s Workers/KV cache to reactively invalidate affected entries, reducing requests to Fill while keeping cached data fresher than polling-based invalidation would allow.

Webhooks can be listed, created, and deleted through the GraphQL API with `API_MANAGE` authorization, with secrets returned only when a webhook is created.

Deliveries follow the Standard Webhooks signing specification and cover `build.published`, `build.promoted`, `version.created`, and `version.updated` events. Events identify the affected resources so consumers can refetch them from the API after invalidating their caches. Delivery is asynchronous and uses bounded concurrency, backpressure, timeouts, and exponential-backoff retries. The most recent delivery status and timestamp are recorded for each webhook.

This also replaces the existing build-listener mechanism with Spring application events and migrates Discord notifications to the new event system, ensuring notification failures do not fail otherwise successful publishing or promotion requests.
