### PR TITLE
fix: migrate Jackson 2 usages to Jackson 3

### DIFF
--- a/src/main/java/io/papermc/fill/jackson/LegacyBuildChannelSerializer.java
+++ b/src/main/java/io/papermc/fill/jackson/LegacyBuildChannelSerializer.java
@@ -15,12 +15,12 @@
  */
 package io.papermc.fill.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.papermc.fill.model.BuildChannel;
-import java.io.IOException;
 import org.jspecify.annotations.NullMarked;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 @Deprecated(forRemoval = true)
 @NullMarked
@@ -30,7 +30,7 @@ public class LegacyBuildChannelSerializer extends StdSerializer<BuildChannel> {
   }
 
   @Override
-  public void serialize(final BuildChannel value, final JsonGenerator gen, final SerializerProvider provider) throws IOException {
+  public void serialize(final BuildChannel value, final JsonGenerator gen, final SerializationContext context) throws JacksonException {
     gen.writeString(switch (value) {
       case ALPHA -> "experimental";
       case BETA -> "experimental";

--- a/src/main/java/io/papermc/fill/jackson/ObjectIdSerializer.java
+++ b/src/main/java/io/papermc/fill/jackson/ObjectIdSerializer.java
@@ -15,13 +15,13 @@
  */
 package io.papermc.fill.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import java.io.IOException;
 import org.bson.types.ObjectId;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.boot.jackson.JacksonComponent;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 @JacksonComponent
 @NullMarked
@@ -31,7 +31,7 @@ public class ObjectIdSerializer extends StdSerializer<ObjectId> {
   }
 
   @Override
-  public void serialize(final ObjectId value, final JsonGenerator gen, final SerializerProvider provider) throws IOException {
+  public void serialize(final ObjectId value, final JsonGenerator gen, final SerializationContext context) throws JacksonException {
     gen.writeString(value.toHexString());
   }
 }

--- a/src/main/java/io/papermc/fill/model/response/v2/BuildResponse.java
+++ b/src/main/java/io/papermc/fill/model/response/v2/BuildResponse.java
@@ -16,13 +16,13 @@
 package io.papermc.fill.model.response.v2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.papermc.fill.jackson.LegacyBuildChannelSerializer;
 import io.papermc.fill.model.BuildChannel;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import org.jspecify.annotations.NullMarked;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 @Deprecated(forRemoval = true)
 @NullMarked

--- a/src/main/java/io/papermc/fill/model/response/v2/BuildsResponse.java
+++ b/src/main/java/io/papermc/fill/model/response/v2/BuildsResponse.java
@@ -16,13 +16,13 @@
 package io.papermc.fill.model.response.v2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.papermc.fill.jackson.LegacyBuildChannelSerializer;
 import io.papermc.fill.model.BuildChannel;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import org.jspecify.annotations.NullMarked;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 @Deprecated(forRemoval = true)
 @NullMarked

--- a/src/main/java/io/papermc/fill/model/response/v2/FamilyBuildsResponse.java
+++ b/src/main/java/io/papermc/fill/model/response/v2/FamilyBuildsResponse.java
@@ -16,13 +16,13 @@
 package io.papermc.fill.model.response.v2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.papermc.fill.jackson.LegacyBuildChannelSerializer;
 import io.papermc.fill.model.BuildChannel;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import org.jspecify.annotations.NullMarked;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 @Deprecated(forRemoval = true)
 @NullMarked

--- a/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
+++ b/src/main/java/io/papermc/fill/notification/WebhookPublisher.java
@@ -15,8 +15,6 @@
  */
 package io.papermc.fill.notification;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import io.papermc.fill.database.WebhookEntity;
 import io.papermc.fill.event.FillEvent;
@@ -52,6 +50,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Delivers {@link FillEvent}s to registered webhook endpoints.
@@ -213,7 +213,7 @@ public class WebhookPublisher {
   private byte[] createPayload(final FillEvent event) {
     try {
       return this.json.writeValueAsBytes(WebhookPayload.from(event));
-    } catch (final JsonProcessingException exception) {
+    } catch (final JacksonException exception) {
       throw new IllegalStateException("Could not serialize webhook payload", exception);
     }
   }


### PR DESCRIPTION
Spring Boot provides 3.x; 2.x is still on the classpath transitively, but cannot integrate with Spring (i.e. for autowiring).